### PR TITLE
chore: migrate to mono-claude structure

### DIFF
--- a/.claude/hooks/stop.sh
+++ b/.claude/hooks/stop.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Stop — typecheck after TS changes
+
+TRACKED_TS=$(git diff HEAD --name-only 2>/dev/null | grep '\.ts$')
+UNTRACKED_TS=$(git status --porcelain 2>/dev/null | grep '^\?\?' | awk '{print $2}' | grep '\.ts$')
+ALL_TS=$(printf '%s\n%s\n' "$TRACKED_TS" "$UNTRACKED_TS" | grep -v '^$')
+
+if [ -n "$ALL_TS" ]; then
+  echo "## Post-turn typecheck"
+  bunx tsc --noEmit 2>&1 | tail -30
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "permissions": {
+    "allow": [
+      "Bash(git *)",
+      "Bash(bun *)",
+      "Bash(bunx *)",
+      "Bash(npx *)",
+      "Bash(gh *)"
+    ]
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/stop.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,8 +1,0 @@
-TELEGRAM_BOT_TOKEN=твой_токен_от_BotFather
-DATABASE_URL=postgresql://produser:prodpassword@db:5432/bookclubdb
-POSTGRES_USER=produser
-POSTGRES_PASSWORD=prodpassword
-POSTGRES_DB=bookclubdb
-DATABASE_URL=postgresql://myuser:mypassword@db:5432/bookclubdb
-PORT=3000
-NODE_ENV=production

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# Book Club BE
+
+@package.json
+@CONTRIBUTING.md
+
+## Специфика
+
+- **Runtime:** Bun (не pnpm/npm)
+- **Feature-style архитектура** бота: `src/bot/features/{feature}/`
+- **Env:** один `.env.example`, без разделения dev/prod
+- **Семантические комментарии:** @docs/comment-tags.md

--- a/README.md
+++ b/README.md
@@ -1,12 +1,108 @@
-# Book club BackEnd
+# Book Club BackEnd
 
-### Just our pet project for us
+Backend книжного клуба для фронтенд-разработчиков. NestJS + Prisma + grammY.
 
 ## Get started
 
 1. `bun install`
-2. add `.env` by `.env.example`
+2. Скопируй `.env.example` → `.env`, заполни значения
 3. `docker compose up -d`
 4. `bun run prisma:migrate`
 5. `bun run prisma:gen`
 6. `bun run start:dev`
+
+## Claude Code Setup
+
+Проект использует [Claude Code](https://claude.com/claude-code) как основной AI-инструмент разработки. Настройка ниже.
+
+### 1. Установить Claude Code
+
+```bash
+# VS Code extension или CLI
+npm install -g @anthropic-ai/claude-code
+```
+
+### 2. MCP серверы
+
+Три MCP нужны для полноценной работы. Настраиваются в `~/.claude.json` → `mcpServers`:
+
+**Context7** — актуальные доки библиотек (NestJS, Prisma, grammY):
+
+```bash
+npx ctx7@latest setup
+# Выбрать: MCP server → Claude Code
+# Авторизоваться в браузере
+```
+
+**GitHub** — issues, PR, code search:
+
+```bash
+# Создать classic PAT: GitHub → Settings → Developer settings → Tokens (classic)
+# Scopes: repo, project, read:org
+claude mcp add-json github '{"type":"http","url":"https://api.githubcopilot.com/mcp","headers":{"Authorization":"Bearer YOUR_PAT"}}'
+```
+
+**Figma** — макеты:
+
+```bash
+claude mcp add --transport http --scope user figma https://mcp.figma.com/mcp
+# После рестарта: /mcp → figma → Authenticate
+```
+
+### 3. GitHub CLI
+
+```bash
+gh auth login
+# Если несколько аккаунтов — переключение:
+gh auth switch -u Art-Frich
+```
+
+### 4. Структура контекста
+
+Проект использует **mono-claude** паттерн — общий контекст на уровне организации:
+
+```
+book-club-org/                     ← git repo (bookclubit/book-club-org)
+├── CLAUDE.md                      ← общие правила, архитектура, конвенции
+├── .claude/
+│   ├── skills/                    ← /run, /team-lead, /developer, /review, /spec, /refactor
+│   ├── templates/                 ← шаблоны спек и тест-кейсов
+│   └── references/                ← github-digest.md, figma-digest.md
+│
+└── book-club-be/                  ← этот репо (bookclubit/book-club-be)
+    ├── CLAUDE.md                  ← специфика бэкенда (@package.json, @CONTRIBUTING)
+    └── .claude/
+        ├── settings.json          ← permissions, hooks, env
+        └── hooks/stop.sh          ← typecheck после изменений TS
+```
+
+Claude загружает `CLAUDE.md` из родительских директорий — поэтому при работе в `book-club-be/` видит оба файла.
+
+### 5. Скилы
+
+| Команда      | Что делает                                                          |
+| ------------ | ------------------------------------------------------------------- |
+| `/run`       | Оркестратор — triage задачи, выбор стратегии, полный pipeline до PR |
+| `/spec`      | Создание спеки (tasks.md, requirements.md, design.md)               |
+| `/team-lead` | Мульти-агентная параллельная реализация через worktrees             |
+| `/developer` | Агент-исполнитель (вызывается team-lead'ом)                         |
+| `/review`    | Code review (scoped / deep / scope review)                          |
+| `/refactor`  | Plan-first рефакторинг                                              |
+
+### 6. References
+
+В `.claude/references/` на org-level хранятся дайджесты:
+
+- **github-digest.md** — полная выжимка из GitHub Project: все issues, комменты, принятые решения, release strategy
+- **figma-digest.md** — все экраны макета, user flow, архитектура системы, геймификация, сущности
+
+Эти файлы — контекст для Claude, не для ручного чтения. Обновляются по мере развития проекта.
+
+### 7. Память
+
+Claude хранит контекст между сессиями в `~/.claude/projects/{project}/memory/`:
+
+- `user_profile.md` — профиль разработчика
+- `project_architecture_decisions.md` — ключевые решения
+- `feedback_communication.md` — стиль коммуникации
+- `project_backlog_digest.md` — состояние бэклога


### PR DESCRIPTION
## Что сделано

Первый этап интеграции Claude Code в проект. Настроена базовая инфраструктура для AI-assisted разработки.

### Mono-claude структура
Вместо монорепы используем отдельные git-репо под общим зонтиком `book-club-org/`. Claude загружает `CLAUDE.md` из родительских директорий — видит общий контекст (скилы, архитектура, конвенции) + специфику конкретного репо.

Общий контекст вынесен в отдельный репо: [book-club-org](https://github.com/bookclubit/book-club-org)

### Изменения в этом PR

- **CLAUDE.md** — специфика бэкенда: импорт `@package.json` и `@CONTRIBUTING.md`, bun как runtime, feature-style архитектура бота, семантические комментарии
- **.claude/settings.json** — permissions для bun, bunx, gh; typecheck hook; agent teams
- **.claude/hooks/stop.sh** — автоматический `tsc --noEmit` после изменений TS-файлов
- **README.md** — секция "Claude Code Setup": пошаговая инструкция (MCP серверы, GitHub CLI, структура контекста, скилы, references, память)
- **Удалён .env.prod.example** — политика единого `.env.example`

### Что НЕ входит в этот PR (остаётся в #43)
- Адаптация rules/ (spec-authoring, task-rules, refactoring)
- Адаптация templates/ (убрать Jira-поля)
- Архитектурный документ
- Feature flags модуль

Relates to #43

## Как проверить

- [ ] Claude Code подхватывает `CLAUDE.md` при старте сессии в `book-club-be/`
- [ ] Видит оба уровня: org + be
- [ ] Скилы доступны с org-level
- [ ] Typecheck hook срабатывает после изменения .ts файлов

🤖 Generated with [Claude Code](https://claude.com/claude-code)