### PR TITLE
feat: add feature flag module #45

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "@types/node": "^22.10.7",
         "@types/supertest": "^6.0.2",
         "bun-git-hooks": "^0.3.1",
+        "dotenv": "^17.3.1",
         "dotenv-cli": "^11.0.0",
         "oxfmt": "^0.13.0",
         "oxlint": "^1.28.0",
@@ -466,7 +467,7 @@
 
     "dot-prop": ["dot-prop@5.3.0", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q=="],
 
-    "dotenv": ["dotenv@17.2.3", "", {}, "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w=="],
+    "dotenv": ["dotenv@17.3.1", "", {}, "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA=="],
 
     "dotenv-cli": ["dotenv-cli@11.0.0", "", { "dependencies": { "cross-spawn": "^7.0.6", "dotenv": "^17.1.0", "dotenv-expand": "^12.0.0", "minimist": "^1.2.6" }, "bin": { "dotenv": "cli.js" } }, "sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww=="],
 
@@ -1005,6 +1006,8 @@
     "ajv-keywords/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
     "c12/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
+
+    "dotenv-cli/dotenv": ["dotenv@17.2.3", "", {}, "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w=="],
 
     "dotenv-expand/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/node": "^22.10.7",
     "@types/supertest": "^6.0.2",
     "bun-git-hooks": "^0.3.1",
+    "dotenv": "^17.3.1",
     "dotenv-cli": "^11.0.0",
     "oxfmt": "^0.13.0",
     "oxlint": "^1.28.0",

--- a/prisma/migrations/20260322120000_add_feature_flag/migration.sql
+++ b/prisma/migrations/20260322120000_add_feature_flag/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "FeatureFlag" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT false,
+    "description" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FeatureFlag_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FeatureFlag_name_key" ON "FeatureFlag"("name");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,3 +21,12 @@ model Book {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
+
+model FeatureFlag {
+  id          Int      @id @default(autoincrement())
+  name        String   @unique
+  enabled     Boolean  @default(false)
+  description String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -4,6 +4,7 @@ import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { BotModule } from '../bot/bot.module';
+import { FeatureFlagModule } from '../feature-flag/feature-flag.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { validateEnv } from './validators/env.validation';
 
@@ -14,6 +15,7 @@ import { validateEnv } from './validators/env.validation';
       validate: validateEnv,
     }),
     BotModule,
+    FeatureFlagModule,
     PrismaModule,
   ],
   controllers: [AppController],

--- a/src/feature-flag/feature-flag.constants.ts
+++ b/src/feature-flag/feature-flag.constants.ts
@@ -1,0 +1,1 @@
+export const FEATURE_FLAG_KEY = 'feature_flag';

--- a/src/feature-flag/feature-flag.decorator.ts
+++ b/src/feature-flag/feature-flag.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common';
+
+import { FEATURE_FLAG_KEY } from './feature-flag.constants.js';
+
+export const FeatureFlag = (flagName: string) =>
+  SetMetadata(FEATURE_FLAG_KEY, flagName);

--- a/src/feature-flag/feature-flag.guard.ts
+++ b/src/feature-flag/feature-flag.guard.ts
@@ -1,0 +1,43 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+import { FEATURE_FLAG_KEY } from './feature-flag.constants.js';
+import { FeatureFlagService } from './feature-flag.service.js';
+
+@Injectable()
+export class FeatureFlagGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly featureFlagService: FeatureFlagService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const flagName = this.reflector.getAllAndOverride<string | undefined>(
+      FEATURE_FLAG_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (!flagName) {
+      return true;
+    }
+
+    const isEnabled = await this.featureFlagService.isEnabled(flagName);
+
+    // Flag not found in DB — allow by default
+    if (isEnabled === null) {
+      return true;
+    }
+
+    // Flag found but disabled — block with 404
+    if (!isEnabled) {
+      throw new NotFoundException();
+    }
+
+    return true;
+  }
+}

--- a/src/feature-flag/feature-flag.module.ts
+++ b/src/feature-flag/feature-flag.module.ts
@@ -1,0 +1,12 @@
+import { Global, Module } from '@nestjs/common';
+
+import { PrismaModule } from '../prisma/prisma.module.js';
+import { FeatureFlagService } from './feature-flag.service.js';
+
+@Global()
+@Module({
+  imports: [PrismaModule],
+  providers: [FeatureFlagService],
+  exports: [FeatureFlagService],
+})
+export class FeatureFlagModule {}

--- a/src/feature-flag/feature-flag.service.ts
+++ b/src/feature-flag/feature-flag.service.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@nestjs/common';
+
+import { PrismaService } from '../prisma/prisma.service.js';
+
+interface CacheEntry {
+  value: boolean;
+  cachedAt: number;
+}
+
+const CACHE_TTL_MS = 60_000;
+
+@Injectable()
+export class FeatureFlagService {
+  private cache = new Map<string, CacheEntry>();
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async isEnabled(name: string): Promise<boolean | null> {
+    const cached = this.cache.get(name);
+
+    if (cached && Date.now() - cached.cachedAt < CACHE_TTL_MS) {
+      return cached.value;
+    }
+
+    const flag = await this.prisma.featureFlag.findUnique({ where: { name } });
+
+    if (!flag) {
+      return null;
+    }
+
+    this.cache.set(name, { value: flag.enabled, cachedAt: Date.now() });
+
+    return flag.enabled;
+  }
+
+  async create(data: { name: string; enabled?: boolean; description?: string }) {
+    this.invalidateCache();
+
+    return this.prisma.featureFlag.create({ data });
+  }
+
+  async update(name: string, data: { enabled?: boolean; description?: string }) {
+    this.invalidateCache();
+
+    return this.prisma.featureFlag.update({ where: { name }, data });
+  }
+
+  async delete(name: string) {
+    this.invalidateCache();
+
+    return this.prisma.featureFlag.delete({ where: { name } });
+  }
+
+  async findAll() {
+    return this.prisma.featureFlag.findMany();
+  }
+
+  private invalidateCache() {
+    this.cache.clear();
+  }
+}

--- a/src/feature-flag/index.ts
+++ b/src/feature-flag/index.ts
@@ -1,0 +1,5 @@
+export { FeatureFlagModule } from './feature-flag.module.js';
+export { FeatureFlagService } from './feature-flag.service.js';
+export { FeatureFlagGuard } from './feature-flag.guard.js';
+export { FeatureFlag } from './feature-flag.decorator.js';
+export { FEATURE_FLAG_KEY } from './feature-flag.constants.js';


### PR DESCRIPTION
## Summary

- Добавлена Prisma модель `FeatureFlag` (name unique, enabled bool, description optional) + миграция
- Создан глобальный NestJS модуль `FeatureFlagModule` с сервисом, декоратором и гардом
- `FeatureFlagService` — CRUD операции + in-memory кэш с TTL 60 секунд
- `@FeatureFlag('FLAG_NAME')` — декоратор для контроллеров/эндпоинтов
- `FeatureFlagGuard` — проверяет флаг через сервис: если отключён → 404, если не найден → пропускает
- Модуль зарегистрирован в AppModule
- Добавлена dev-зависимость `dotenv` для корректной работы `prisma.config.ts`

## Структура

```
src/feature-flag/
├── feature-flag.constants.ts   # metadata key
├── feature-flag.decorator.ts   # @FeatureFlag('NAME')
├── feature-flag.guard.ts       # CanActivate guard
├── feature-flag.module.ts      # Global module
├── feature-flag.service.ts     # CRUD + cache
└── index.ts                    # barrel exports
```

## Использование

```typescript
@Controller('books')
@UseGuards(FeatureFlagGuard)
@FeatureFlag('BOOKS_ENABLED')
export class BooksController { ... }
```

## Test plan

- [ ] Запустить `bunx tsc --noEmit` — typecheck проходит
- [ ] Применить миграцию `bun run prisma:migrate` на работающей БД
- [ ] Проверить CRUD через сервис: create, findAll, update, delete
- [ ] Проверить что гард пропускает при enabled=true
- [ ] Проверить что гард возвращает 404 при enabled=false
- [ ] Проверить что гард пропускает при отсутствующем флаге в БД

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)